### PR TITLE
Fullfill issue #1 and bug fix for RUN_KEEPER & checkout branch bug

### DIFF
--- a/prepare-envs.sh
+++ b/prepare-envs.sh
@@ -16,7 +16,7 @@ echo ----- stage: checkout buildkite Steps Env ------
 [[ ! "$MANGO_SIMULATION_REPO" ]]&& MANGO_SIMULATION_REPO=https://github.com/solana-labs/mango-simulation.git && echo MANGO_SIMULATION_REPO env not found, use $MANGO_SIMULATION_REPO
 [[ ! "$MANGO_SIMULATION_BRANCH" ]]&& MANGO_SIMULATION_BRANCH=main && echo MANGO_SIMULATION_BRANCH env not found, use $MANGO_SIMULATION_BRANCH
 [[ ! "$MANGO_SIMULATION_DIR" ]]&& MANGO_SIMULATION_DIR=/home/sol/mango_simulation && echo MANGO_SIMULATION_DIR env not found, use $MANGO_SIMULATION_DIR
-[[ ! "$RUN_KEEPER" ]] && RUN_KEEPER=true && echo no RUN_KEEPER , use $RUN_KEEPER
+[[ ! "$RUN_KEEPER" ]] && RUN_KEEPER="true" && echo no RUN_KEEPER , use $RUN_KEEPER
 [[ ! "$MANGO_CONFIGURE_REPO" ]]&& MANGO_CONFIGURE_REPO=https://github.com/solana-labs/configure_mango.git && echo MANGO_CONFIGURE_REPO env not found, use $MANGO_CONFIGURE_REPO
 [[ ! "$MANGO_CONFIGURE_DIR" ]] && MANGO_CONFIGURE_DIR=configure_mango && echo no MANGO_CONFIGURE_DIR , use $MANGO_CONFIGURE_DIR
 ## CI program ENVS
@@ -51,6 +51,7 @@ echo "QOUTES_PER_SECOND=$QOUTES_PER_SECOND" >> env-artifact.sh
 echo "AUTHORITY_FILE=$AUTHORITY_FILE" >> env-artifact.sh
 echo "ID_FILE=$ID_FILE" >> env-artifact.sh
 echo "ACCOUNTS=\"$ACCOUNTS\"" >> env-artifact.sh
+echo "RUN_KEEPER=$RUN_KEEPER" >> env-artifact.sh
 echo "SAVE_TRANSACTIONS_LOG=$SAVE_TRANSACTIONS_LOG" >> env-artifact.sh
 # Keeper Run Envs
 echo "CLUSTER=$CLUSTER" >> env-artifact.sh

--- a/prepare-envs.sh
+++ b/prepare-envs.sh
@@ -73,6 +73,7 @@ echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> env-artifact.sh
 echo "KEEP_INSTANCES=$KEEP_INSTANCES" >> env-artifact.sh
 echo "TERMINATION_CHECK_INTERVAL=$TERMINATION_CHECK_INTERVAL" >> env-artifact.sh
 # buildkite build envs
+echo "BUILDKITE_BRANCH=$BUILDKITE_BRANCH" >> env-artifact.sh
 echo "BUILDKITE_PIPELINE_ID=$BUILDKITE_PIPELINE_ID" >> env-artifact.sh
 echo "BUILDKITE_BUILD_ID=$BUILDKITE_BUILD_ID" >> env-artifact.sh
 echo "BUILDKITE_JOB_ID=$BUILDKITE_JOB_ID" >> env-artifact.sh

--- a/prepare-envs.sh
+++ b/prepare-envs.sh
@@ -9,6 +9,7 @@ echo ----- stage: checkout buildkite Steps Env ------
 [[ ! "$ACCOUNTS" ]]&& ACCOUNTS="accounts-1_20.json accounts-2_20.json accounts-3_10.json" && echo ACCOUNTS not found, use $ACCOUNTS
 [[ ! "$AUTHORITY_FILE" ]] && AUTHORITY_FILE=authority.json && echo AUTHORITY_FILE , use $AUTHORITY_FILE
 [[ ! "$ID_FILE" ]] && ID_FILE=ids.json && echo ID_FILE , use $ID_FILE
+[[ ! "$SAVE_TRANSACTIONS_LOG" ]] && SAVE_TRANSACTIONS_LOG="true" && ehco SAVE_TRANSACTIONS_LOG not found, use $SAVE_TRANSACTIONS_LOG
 ## keeper_run run ENVS
 [[ ! "$CLUSTER" ]] && KEEPER_CLUSTER=testnet && echo KEEPER_CLUSTER , use $KEEPER_CLUSTER
 ## mango-simulation build repo ENVS
@@ -50,6 +51,7 @@ echo "QOUTES_PER_SECOND=$QOUTES_PER_SECOND" >> env-artifact.sh
 echo "AUTHORITY_FILE=$AUTHORITY_FILE" >> env-artifact.sh
 echo "ID_FILE=$ID_FILE" >> env-artifact.sh
 echo "ACCOUNTS=\"$ACCOUNTS\"" >> env-artifact.sh
+echo "SAVE_TRANSACTIONS_LOG=$SAVE_TRANSACTIONS_LOG" >> env-artifact.sh
 # Keeper Run Envs
 echo "CLUSTER=$CLUSTER" >> env-artifact.sh
 #mango-simulation build repo ENVS

--- a/prepare-envs.sh
+++ b/prepare-envs.sh
@@ -9,7 +9,7 @@ echo ----- stage: checkout buildkite Steps Env ------
 [[ ! "$ACCOUNTS" ]]&& ACCOUNTS="accounts-1_20.json accounts-2_20.json accounts-3_10.json" && echo ACCOUNTS not found, use $ACCOUNTS
 [[ ! "$AUTHORITY_FILE" ]] && AUTHORITY_FILE=authority.json && echo AUTHORITY_FILE , use $AUTHORITY_FILE
 [[ ! "$ID_FILE" ]] && ID_FILE=ids.json && echo ID_FILE , use $ID_FILE
-[[ ! "$SAVE_TRANSACTIONS_LOG" ]] && SAVE_TRANSACTIONS_LOG="true" && ehco SAVE_TRANSACTIONS_LOG not found, use $SAVE_TRANSACTIONS_LOG
+[[ ! "$SAVE_TRANSACTIONS_LOG" ]] && SAVE_TRANSACTIONS_LOG="false" && ehco SAVE_TRANSACTIONS_LOG not found, use $SAVE_TRANSACTIONS_LOG
 ## keeper_run run ENVS
 [[ ! "$CLUSTER" ]] && KEEPER_CLUSTER=testnet && echo KEEPER_CLUSTER , use $KEEPER_CLUSTER
 ## mango-simulation build repo ENVS

--- a/start-build-dependency.sh
+++ b/start-build-dependency.sh
@@ -69,6 +69,9 @@ echo ------- stage: git clone repos ------
 cd $HOME
 [[ -d "$GIT_REPO_DIR" ]]&& rm -rf $GIT_REPO_DIR
 git clone "$GIT_REPO"
+cd $GIT_REPO_DIR
+git checkout "$BUILDKITE_BRANCH"
+git checkout "$GIT_BRANCH"
 [[ -d "$HOME/$MANGO_CONFIGURE_DIR" ]]&& rm -rf "$HOME/$MANGO_CONFIGURE_DIR"
 git clone "$MANGO_CONFIGURE_REPO" # may remove later
 [[ -d "$HOME/$MANGO_SIMULATION_DIR" ]]&& rm -rf "$HOME/$MANGO_SIMULATION_DIR"

--- a/start-build-dependency.sh
+++ b/start-build-dependency.sh
@@ -72,7 +72,6 @@ git clone "$GIT_REPO"
 cd $GIT_REPO_DIR
 git checkout "$BUILDKITE_BRANCH"
 cd $HOME
-git checkout "$GIT_BRANCH"
 [[ -d "$HOME/$MANGO_CONFIGURE_DIR" ]]&& rm -rf "$HOME/$MANGO_CONFIGURE_DIR"
 git clone "$MANGO_CONFIGURE_REPO" # may remove later
 [[ -d "$HOME/$MANGO_SIMULATION_DIR" ]]&& rm -rf "$HOME/$MANGO_SIMULATION_DIR"

--- a/start-build-dependency.sh
+++ b/start-build-dependency.sh
@@ -71,6 +71,7 @@ cd $HOME
 git clone "$GIT_REPO"
 cd $GIT_REPO_DIR
 git checkout "$BUILDKITE_BRANCH"
+cd $HOME
 git checkout "$GIT_BRANCH"
 [[ -d "$HOME/$MANGO_CONFIGURE_DIR" ]]&& rm -rf "$HOME/$MANGO_CONFIGURE_DIR"
 git clone "$MANGO_CONFIGURE_REPO" # may remove later

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -93,10 +93,13 @@ args=(
   --mango-cluster $b_mango_cluster
   --duration $b_duration
   --quotes-per-second $b_q
-  --transaction-save-file $b_tx_save_f
   --block-data-save-file $b_block_save_f
   --markets-per-mm 5
 )
+
+if [[ "$SAVE_TRANSACTIONS_LOG" == "true" ]]; then
+  args+=(--transaction-save-file $b_tx_save_f)
+fi
 
 if [[ "$RUN_KEEPER" == "true" ]] ;then
     args+=(--keeper-authority authority.json)

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -17,7 +17,7 @@ source $HOME/env-artifact.sh
 [[ ! "$AUTHORITY_FILE" ]] && echo no AUTHORITY_FILE && exit 1
 [[ ! "$ID_FILE" ]] && echo no ID_FILE && exit 1
 [[ ! "$1" ]]&& echo no ACCOUNT_FILE as arg1 && exit 1 || ACCOUNT_FILE="$1"
-[[ ! "$2" ]]&& echo no NO RUN_KEEPER as arg2 && exit 1 || RUN_KEEPER="$2"
+[[ ! "$2" ]]&& echo no RUN_KEEPER as arg2 && exit 1 || RUN_KEEPER="$2"
 
 
 #### metrics env ####

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -17,7 +17,7 @@ source $HOME/env-artifact.sh
 [[ ! "$AUTHORITY_FILE" ]] && echo no AUTHORITY_FILE && exit 1
 [[ ! "$ID_FILE" ]] && echo no ID_FILE && exit 1
 [[ ! "$1" ]]&& echo no ACCOUNT_FILE as arg1 && exit 1 || ACCOUNT_FILE="$1"
-[[ ! "$2" ]]&& echo no NO RUN_KEEPER as arg2 && exit 1 || RUN_KEEPER="\"$2\""
+[[ ! "$2" ]]&& echo no NO RUN_KEEPER as arg2 && exit 1 || RUN_KEEPER="$2"
 
 
 #### metrics env ####

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -93,6 +93,7 @@ args=(
   --mango-cluster $b_mango_cluster
   --duration $b_duration
   --quotes-per-second $b_q
+  --block-data-save-file $b_block_save_f
   --markets-per-mm 5
 )
 

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -107,7 +107,9 @@ fi
 
 ret_bench=$(./mango-simulation "${args[@]}" 2> $b_error_f &)
 echo --- stage: tar log files ---
-tar --remove-files -czf "${b_tx_save_f}.tar.gz" ${b_tx_save_f} || true
+if [[ "$SAVE_TRANSACTIONS_LOG" == "true" ]]; then
+  tar --remove-files -czf "${b_tx_save_f}.tar.gz" ${b_tx_save_f} || true
+fi
 [[ -f "$HOME/start-dos-test.nohup" ]] && cp "$HOME/start-dos-test.nohup" "$HOME/$HOSTNAME" || true
 echo --- end of benchmark $(date)
 exit 0

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -93,7 +93,6 @@ args=(
   --mango-cluster $b_mango_cluster
   --duration $b_duration
   --quotes-per-second $b_q
-  --block-data-save-file $b_block_save_f
   --markets-per-mm 5
 )
 


### PR DESCRIPTION
Problem
When run the mango test with option flag may take 2/3 time of test Duration to generate transaction-save-log.
This will make long-term run not possible.

Summary of Changes
- I  added an ENV to turn on/off the option for mango-simulation. 
- I found 2 bugs during the test adding the option and fixed them. One is RUN_KEEPER value bug and another is checkout out branch in clients.