### PR TITLE
Report to influxdb

### DIFF
--- a/create-instance.sh
+++ b/create-instance.sh
@@ -67,9 +67,9 @@ function create_machines() {
         echo "gc instance is created in $zone"
         sleep $create_interval # avoid too quick build
     done
-    echo ${instance_ip[@]} > instance_ip.out
-    echo ${instance_zone[@]} > instance_name.out
-    echo ${instance_zone[@]} > instance_zone.out
+    echo "${instance_ip[@]}" > instance_ip.out
+    echo "${instance_zone[@]}" > instance_name.out
+    echo "${instance_zone[@]}" > instance_zone.out
 }
 
 function append_machines() {
@@ -84,16 +84,14 @@ function append_machines() {
         echo "gc instance is created in $zone"
         sleep $create_interval # avoid too quick build
     done
-    echo ${instance_ip[@]} > instance_ip.out
-    echo ${instance_zone[@]} > instance_name.out
-    echo ${instance_zone[@]} > instance_zone.out
+    echo "${instance_ip[@]}" > instance_ip.out
+    echo "${instance_zone[@]}" > instance_name.out
+    echo "${instance_zone[@]}" > instance_zone.out
 }
 
 
 function delete_machines(){
     echo ----- stage: remove gc instances ------
-	echo "instance_name : ${instance_name[@]}"
-	echo "instance_zone : ${instance_zone[@]}"
 	for idx in "${!instance_name[@]}"
 	do
 		gcloud compute instances delete --quiet ${instance_name[$idx]} --zone=${instance_zone[$idx]}

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -150,101 +150,138 @@ get_value() {
 		_value="na"
 	fi
 }
+
+declare -A DATAPOINT # collect results
+# write data to benchmark-report-tmp bucket
+# $2:influxdb endpoint $data to write
+write_datapoint_v2() {
+    curl -i --connect-timeout "${CURL_TIMEOUT}" -XPOST "${INFLUX_HOST}/api/v2/write?bucket=${REPORT_BUCKET}/autogen&precision=ns" \
+    --header "${HEADER_AUTH}" \
+    --data-raw "$1"
+}
+
 result_detail=""
+# time for influx only
+DATAPOINT[start_time]="$start_time"
+DATAPOINT[stop_time]="$stop_time"
+printf -v time_range_str 'time range: %s ~ %s' \
+        "$(date --rfc-3339=seconds -u -d @$start_time)" "$(date --rfc-3339=seconds -u -d @$stop_time)"
+DATAPOINT[time_range]="$time_range_str"
 # slot
 result_input=${FLUX_RESULT['start_slot']}
 get_value
 start_slot_txt="start_slot: $_value"
+DATAPOINT[start_slot]="$_value"
 result_input=${FLUX_RESULT['end_slot']}
 get_value
 end_slot_txt="end_slot: $_value"
-
+DATAPOINT[end_slot]="$_value"
 #  TPS
 result_input=${FLUX_RESULT['mean_tx_count']}
 get_value
 mean_tx_count_txt="mean_tps: $_value"
+DATAPOINT[mean_tps]="$_value"
 result_input=${FLUX_RESULT['max_tx_count']}
 get_value
 max_tx_count_txt="max_tps: $_value"
+DATAPOINT[max_tps]="$_value"
 result_input=${FLUX_RESULT['p90_tx_count']}
 get_value
 p90_tx_count_txt="90th_tx_count: $_value"
+DATAPOINT[90th_tx_count]="$_value"
 result_input="${FLUX_RESULT['p99_tx_count']}"
 get_value
 p99_tx_count_txt="99th_tx_count: $_value"
-
+DATAPOINT[99th_tx_count]="$_value"
 # tower distance
 result_input="${FLUX_RESULT['mean_tower_vote_distance']}"
 echo "${FLUX_RESULT['mean_tower_vote_distance']}"
 get_value
 mean_tower_vote_distance_txt="mean_tower_vote_distance: $_value"
+DATAPOINT[mean_tower_vote_distance]="$_value"
 result_input="${FLUX_RESULT['max_tower_vote_distance']}"
 get_value
 max_tower_vote_distance_txt="max_tower_vote_distance: $_value"
+DATAPOINT[max_tower_vote_distance]="$_value"
 result_input="${FLUX_RESULT['min_tower_vote_distance']}"
 get_value
 result_input="${FLUX_RESULT['p90_tower_vote_distance']}"
 get_value
 p90_tower_vote_distance_txt="90th_tower_vote_distance: $_value"
+DATAPOINT[90th_tower_vote_distance]="$_value"
 result_input="${FLUX_RESULT['p99_tower_vote_distance']}"
 get_value
 p99_tower_vote_distance_txt="99th_tower_vote_distance: $_value"
-
+DATAPOINT[99th_tower_vote_distance]="$_value"
 # optimistic_slot_elapsed
 result_input="${FLUX_RESULT['mean_optimistic_slot_elapsed']}"
 get_value
 mean_optimistic_slot_elapsed_txt="mean_optimistic_slot_elapsed: $_value"
+DATAPOINT[mean_optimistic_slot_elapsed]="$_value"
 result_input="${FLUX_RESULT['max_optimistic_slot_elapsed']}"
 get_value
 max_optimistic_slot_elapsed_txt="max_optimistic_slot_elapsed: $_value"
+DATAPOINT[max_optimistic_slot_elapsed]="$_value"
 result_input="${FLUX_RESULT['p90_optimistic_slot_elapsed']}"
 get_value
 p90_optimistic_slot_elapsed_txt="90th_optimistic_slot_elapsed: $_value"
 result_input="${FLUX_RESULT['p99_optimistic_slot_elapsed']}"
+DATAPOINT[90th_optimistic_slot_elapsed]="$_value"
 get_value
 p99_optimistic_slot_elapsed_txt="99th_optimistic_slot_elapsed: $_value"
-
+DATAPOINT[99th_optimistic_slot_elapsed]="$_value"
 # ct_stats_block_cost
 result_input="${FLUX_RESULT['mean_ct_stats_block_cost']}"
 get_value
 mean_ct_stats_block_cost_txt="mean_cost_tracker_stats_block_cost: $_value"
+DATAPOINT[mean_cost_tracker_stats_block_cost]="$_value"
 result_input="${FLUX_RESULT['max_ct_stats_block_cost']}"
 get_value
 max_ct_stats_block_cost_txt="max_cost_tracker_stats_block_cost: $_value"
+DATAPOINT[max_cost_tracker_stats_block_cost]="$_value"
 result_input="${FLUX_RESULT['p90_ct_stats_block_cost']}"
 get_value
 p90_ct_stats_block_cost_txt="90th_cost_tracker_stats_block_cost: $_value"
+DATAPOINT[90th_cost_tracker_stats_block_cost]="$_value"
 result_input="${FLUX_RESULT['p99_ct_stats_block_cost']}"
 get_value
 p99_ct_stats_block_cost_txt="99th_cost_tracker_stats_block_cost: $_value"
+DATAPOINT[99th_cost_tracker_stats_block_cost]="$_value"
 
 # ct_stats_block_cost
 result_input="${FLUX_RESULT['mean_ct_stats_transaction_count']}"
 get_value
 mean_mean_ct_stats_tx_count_txt="mean_cost_tracker_stats_transaction_count: $_value"
+DATAPOINT[mean_cost_tracker_stats_transaction_count]="$_value"
 result_input="${FLUX_RESULT['max_ct_stats_transaction_count']}"
 get_value
 max_mean_ct_stats_tx_count_txt="max_cost_tracker_stats_transaction_count: $_value"
+DATAPOINT[max_cost_tracker_stats_transaction_count]="$_value"
 result_input="${FLUX_RESULT['p90_ct_stats_transaction_count']}"
 get_value
 p90_mean_ct_stats_tx_count_txt="90th_cost_tracker_stats_transaction_count: $_value"
+DATAPOINT[90th_cost_tracker_stats_transaction_count]="$_value"
 result_input="${FLUX_RESULT['p99_ct_stats_transaction_count']}"
 get_value
 p99_mean_ct_stats_tx_count_txt="99th_cost_tracker_stats_transaction_count: $_value"
-
+DATAPOINT[99th_cost_tracker_stats_transaction_count]="$_value"
 # ct_stats_number_of_accounts
 result_input="${FLUX_RESULT['mean_ct_stats_number_of_accounts']}"
 get_value
 mean_ct_stats_num_of_accts_txt="mean_cost_tracker_stats_number_of_accounts: $_value"
+DATAPOINT[mean_cost_tracker_stats_number_of_accounts]="$_value"
 result_input="${FLUX_RESULT['max_ct_stats_number_of_accounts']}"
 get_value
 max_ct_stats_num_of_accts_txt="max_cost_tracker_stats_number_of_accounts: $_value"
+DATAPOINT[max_cost_tracker_stats_number_of_accounts]="$_value"
 result_input="${FLUX_RESULT['p90_ct_stats_number_of_accounts']}"
 get_value
 p90_ct_stats_num_of_accts_txt="90th_cost_tracker_stats_number_of_accounts: $_value"
+DATAPOINT[90th_cost_tracker_stats_number_of_accounts]="$_value"
 result_input="${FLUX_RESULT['p99_ct_stats_number_of_accounts']}"
 get_value
 p99_ct_stats_num_of_accts_txt="99th_cost_tracker_stats_number_of_accounts: $_value"
+DATAPOINT[99th_cost_tracker_stats_number_of_accounts]="$_value"
 
 # # blocks fill
 result_input="${FLUX_RESULT['total_blocks']}"
@@ -254,27 +291,48 @@ if [[ "$_value" == "na" ]];then
 fi
 total_blocks_tmp=$_value
 total_blocks_txt="numb_total_blocks: $_value"
-
+DATAPOINT[numb_total_blocks]="$_value"
 result_input="${FLUX_RESULT['blocks_fill_50']}"
 get_value
 blocks_fill_50_txt="numb_blocks_50_full: $_value"
+DATAPOINT[numb_blocks_50_full]="$_value"
 if [[ "$_value" == "na" || $total_blocks_tmp -eq 0 ]];then
 	percent_value="0%"
+	percent_raw_value=0
 else 
-	echo value : $(echo "($_value/$total_blocks_tmp)*100" | bc)
-	printf -v percent_value "%.0f%s" $(echo "scale=2;($_value/$total_blocks_tmp)*100" | bc) "%"
+	percent_raw_value=$(echo "scale=2;($_value/$total_blocks_tmp)*100" | bc)
+	printf -v percent_value "%.0f%s" $percent_raw_value "%"
 fi
 blocks_fill_50_percent_txt="blocks_50_full: $percent_value"
-
+DATAPOINT[blocks_50_full]="$percent_raw_value"
 result_input="${FLUX_RESULT['blocks_fill_90']}"
 get_value
 blocks_fill_90_txt="numb_blocks_90_full: $_value"
+DATAPOINT[numb_blocks_90_full]="$_value"
 if [[ "$_value" == "na" || $total_blocks_tmp -eq 0 ]];then
 	percent_value="0%"
-else 
-	printf -v percent_value "%.0f%s" $(echo "scale=2;($_value/$total_blocks_tmp)*100" | bc) "%"
+	percent_raw_value=0
+else
+	percent_raw_value=$(echo "scale=2;($_value/$total_blocks_tmp)*100" | bc)
+	printf -v percent_value "%.0f%s" $percent_raw_value "%"
 fi
 blocks_fill_90_percent_txt="blocks_90_full: $percent_value"
+DATAPOINT[blocks_90_full]="$percent_raw_value"
+
+#write data report to the influx
+
+build="$BUILDKITE_BUILD_ID"
+[[ ! "$BUILDKITE_BUILD_ID" ]] && build="na"
+utc_sec=$(date +%s)
+write_ts=$(echo "scale=2;${utc_sec}*1000000000" | bc)
+
+for r in "${!DATAPOINT[@]}"
+do
+	measurement=${FIELD_MEASUREMENT[$r]}
+	write_data="$measurement,build=$build,test_type=$test_type,client=$client,branch=$SOLANA_BUILD_BRANCH,git_commit=$git_commit,cluster_version=$cluster_version,\
+clients_num=$num_clients,duration=$duration,tx_count=$tx_count,thread_batch_sleep_ms=$thread_batch_sleep_ms,durable_nonce=$USE_DURABLE_NONCE $r=${DATAPOINT[$r]} $write_ts"
+    write_datapoint_v2 "$write_data" "$API_V2_HOST"
+done
 
 ## create Grafana link
 gf_from=$(echo "scale=2;${start_time}*1000" | bc)

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -155,7 +155,7 @@ declare -A DATAPOINT # collect results
 # write data to benchmark-report-tmp bucket
 # $2:influxdb endpoint $data to write
 write_datapoint_v2() {
-    curl -i --connect-timeout "${CURL_TIMEOUT}" -XPOST "${INFLUX_HOST}/api/v2/write?bucket=${REPORT_BUCKET}/autogen&precision=ns" \
+    curl -i --connect-timeout "${CURL_TIMEOUT}" -XPOST "${INFLUX_HOST}/api/v2/write?bucket=${DOS_REPORT_BUCKET}/autogen&precision=ns" \
     --header "${HEADER_AUTH}" \
     --data-raw "$1"
 }

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -321,16 +321,15 @@ DATAPOINT[blocks_90_full]="$percent_raw_value"
 
 #write data report to the influx
 
-build="$BUILDKITE_BUILD_ID"
-[[ ! "$BUILDKITE_BUILD_ID" ]] && build="na"
+build="$BUILDKITE_BUILD_NUMBER"
+[[ ! "$BUILDKITE_BUILD_NUMBER" ]] && build="0"
 utc_sec=$(date +%s)
 write_ts=$(echo "scale=2;${utc_sec}*1000000000" | bc)
 
 for r in "${!DATAPOINT[@]}"
 do
 	measurement=${FIELD_MEASUREMENT[$r]}
-	write_data="$measurement,build=$build,test_type=$test_type,client=$client,branch=$SOLANA_BUILD_BRANCH,git_commit=$git_commit,cluster_version=$cluster_version,\
-clients_num=$num_clients,duration=$duration,tx_count=$tx_count,thread_batch_sleep_ms=$thread_batch_sleep_ms,durable_nonce=$USE_DURABLE_NONCE $r=${DATAPOINT[$r]} $write_ts"
+	write_data="$measurement,build=$build,cluster_version=$cluster_version,number_of_clients=$num_clients,duration=$duration,qoutes_per_second=$qoutes_per_second $r=${DATAPOINT[$r]} $write_ts"
     write_datapoint_v2 "$write_data" "$API_V2_HOST"
 done
 

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -6,7 +6,6 @@ source dos-report-env.sh
 source env-artifact.sh
 # check ENV
 # no env , exit
-[[ ! $SLACK_WEBHOOK ]]&&[[ ! $DISCORD_WEBHOOK ]]&& echo no WEBHOOK found&&exit 1
 [[ ! $DISCORD_AVATAR_URL ]]&&DISCORD_AVATAR_URL="https://i.imgur.com/LJismmJ.jpg" || echo use DISCORD_AVATAR_URL=$DISCORD_AVATAR_URL
 [[ ! $START_TIME ]]&& echo START_TIME env not found&&exit 1
 [[ ! $START_TIME2 ]]&& echo START_TIME2 env not found&&exit 1
@@ -164,7 +163,7 @@ result_detail=""
 # time for influx only
 DATAPOINT[start_time]="$start_time"
 DATAPOINT[stop_time]="$stop_time"
-printf -v time_range_str 'time range: %s ~ %s' \
+printf -v time_range_str "\"%s ~ %s\"" \
         "$(date --rfc-3339=seconds -u -d @$start_time)" "$(date --rfc-3339=seconds -u -d @$stop_time)"
 DATAPOINT[time_range]="$time_range_str"
 # slot
@@ -329,7 +328,8 @@ write_ts=$(echo "scale=2;${utc_sec}*1000000000" | bc)
 for r in "${!DATAPOINT[@]}"
 do
 	measurement=${FIELD_MEASUREMENT[$r]}
-	write_data="$measurement,build=$build,cluster_version=$cluster_version,number_of_clients=$num_clients,duration=$duration,qoutes_per_second=$qoutes_per_second $r=${DATAPOINT[$r]} $write_ts"
+	write_data="$measurement,build=$build,cluster_version=$cluster_version,number_of_clients=$num_clients,duration=$duration,\
+qoutes_per_second=$qoutes_per_second $r=${DATAPOINT[$r]} $write_ts"
     write_datapoint_v2 "$write_data" "$API_V2_HOST"
 done
 

--- a/influx_data.sh
+++ b/influx_data.sh
@@ -255,3 +255,49 @@ FLUX[p99_ct_stats_number_of_accounts]=$_99_ct_stats_number_of_accounts
 FLUX[total_blocks]=$_total_blocks
 FLUX[blocks_fill_50]=$_blocks_fill_50
 FLUX[blocks_fill_90]=$_blocks_fill_90
+
+# Dos Report write to Influxdb
+
+declare -A FIELD_MEASUREMENT
+# measurement range
+FIELD_MEASUREMENT[start_time]=range
+FIELD_MEASUREMENT[stop_time]=range
+FIELD_MEASUREMENT[time_range]=range
+FIELD_MEASUREMENT[start_slot]=range
+FIELD_MEASUREMENT[end_slot]=range
+# tps
+FIELD_MEASUREMENT[mean_tps]=tps
+FIELD_MEASUREMENT[max_tps]=tps
+FIELD_MEASUREMENT[90th_tx_count]=tps
+FIELD_MEASUREMENT[99th_tx_count]=tps
+# tower_vote
+FIELD_MEASUREMENT[mean_tower_vote_distance]=tower_vote
+FIELD_MEASUREMENT[max_tower_vote_distance]=tower_vote
+FIELD_MEASUREMENT[90th_tower_vote_distance]=tower_vote
+FIELD_MEASUREMENT[99th_tower_vote_distance]=tower_vote
+# optimistic_slot_elapsed
+FIELD_MEASUREMENT[mean_optimistic_slot_elapsed]=optimistic_slot_elapsed
+FIELD_MEASUREMENT[max_optimistic_slot_elapsed]=optimistic_slot_elapsed
+FIELD_MEASUREMENT[90th_optimistic_slot_elapsed]=optimistic_slot_elapsed
+FIELD_MEASUREMENT[99th_optimistic_slot_elapsed]=optimistic_slot_elapsed
+# cost_tracker_stats
+FIELD_MEASUREMENT[mean_cost_tracker_stats_block_cost]=block_cost
+FIELD_MEASUREMENT[max_cost_tracker_stats_block_cost]=block_cost
+FIELD_MEASUREMENT[90th_cost_tracker_stats_block_cost]=block_cost
+FIELD_MEASUREMENT[99th_cost_tracker_stats_block_cost]=block_cost
+# transaction_count
+FIELD_MEASUREMENT[mean_cost_tracker_stats_transaction_count]=transaction_count
+FIELD_MEASUREMENT[max_cost_tracker_stats_transaction_count]=transaction_count
+FIELD_MEASUREMENT[90th_cost_tracker_stats_transaction_count]=transaction_count
+FIELD_MEASUREMENT[99th_cost_tracker_stats_transaction_count]=transaction_count
+# ct_stats_number_of_accounts
+FIELD_MEASUREMENT[mean_cost_tracker_stats_number_of_accounts]=number_of_accounts
+FIELD_MEASUREMENT[max_cost_tracker_stats_number_of_accounts]=number_of_accounts
+FIELD_MEASUREMENT[90th_cost_tracker_stats_number_of_accounts]=number_of_accounts
+FIELD_MEASUREMENT[99th_cost_tracker_stats_number_of_accounts]=number_of_accounts
+# blocks fill
+FIELD_MEASUREMENT[numb_total_blocks]=block_fill
+FIELD_MEASUREMENT[numb_blocks_50_full]=block_fill
+FIELD_MEASUREMENT[numb_blocks_90_full]=block_fill
+FIELD_MEASUREMENT[blocks_50_full]=block_fill
+FIELD_MEASUREMENT[blocks_90_full]=block_fill

--- a/prepare-envs.sh
+++ b/prepare-envs.sh
@@ -94,6 +94,7 @@ echo "MANGO_SIMULATION_ARTIFACT_FILE=mango-simulation" >> env-artifact.sh
 echo "LARGE_DATA_SET=$LARGE_DATA_SET" >> env-artifact.sh
 echo "INFLUX_WINDOW_INTERVAL=$INFLUX_WINDOW_INTERVAL" >> env-artifact.sh
 echo "INFLUX_WINDOW_INTERVAL_LONG=$INFLUX_WINDOW_INTERVAL_LONG" >> env-artifact.sh
-
+# Report to influxdb
+echo "DOS_REPORT_BUCKET=$DOS_REPORT_BUCKET" >> env-artifact.sh
 cat dos-metrics-env.sh >> env-artifact.sh
 exit 0

--- a/prepare-envs.sh
+++ b/prepare-envs.sh
@@ -41,8 +41,7 @@ echo ----- stage: prepare metrics env for both query and write ------
 [[ -f "dos-metrics-env.sh" ]]&& rm dos-metrics-env.sh
 download_file "gs://$MANGO_SIMULATION_PRIVATE_BUCKET" dos-metrics-env.sh ./
 [[ ! -f "dos-metrics-env.sh" ]]&& echo "NO dos-metrics-env.sh found" && exit 1
-[[ ! -f "dos-metrics-env.sh" ]]&& echo "NO dos-metrics-env.sh found" && exit 1
-[[ ! $REPORT_BUCKET ]] && REPORT_BUCKET="benchmark-report-tmp" && echo no REPORT_BUCKET use "$REPORT_BUCKET"
+[[ ! $DOS_REPORT_BUCKET ]] && DOS_REPORT_BUCKET="mango-simulation-dos" && echo no DOS_REPORT_BUCKET use "$DOS_REPORT_BUCKET"
 
 echo ----- stage: prepare ssh key to dynamic clients ------
 download_file "gs://$MANGO_SIMULATION_PRIVATE_BUCKET" id_ed25519_dos_test ./

--- a/prepare-envs.sh
+++ b/prepare-envs.sh
@@ -37,10 +37,12 @@ echo ----- stage: checkout buildkite Steps Env ------
 [[ ! $INFLUX_WINDOW_INTERVAL_LONG ]] && INFLUX_WINDOW_INTERVAL_LONG="30m"
 
 source utils.sh
-echo ----- stage: prepare metrics env ------ 
+echo ----- stage: prepare metrics env for both query and write ------ 
 [[ -f "dos-metrics-env.sh" ]]&& rm dos-metrics-env.sh
 download_file "gs://$MANGO_SIMULATION_PRIVATE_BUCKET" dos-metrics-env.sh ./
 [[ ! -f "dos-metrics-env.sh" ]]&& echo "NO dos-metrics-env.sh found" && exit 1
+[[ ! -f "dos-metrics-env.sh" ]]&& echo "NO dos-metrics-env.sh found" && exit 1
+[[ ! $REPORT_BUCKET ]] && REPORT_BUCKET="benchmark-report-tmp" && echo no REPORT_BUCKET use "$REPORT_BUCKET"
 
 echo ----- stage: prepare ssh key to dynamic clients ------
 download_file "gs://$MANGO_SIMULATION_PRIVATE_BUCKET" id_ed25519_dos_test ./


### PR DESCRIPTION
[Problem]
We want the mango-simulation report saved in the influxdb
[solution]
Save the report in influxdb as
Name the db as the test it’s running
All the test configs as tags
Group the test results as measurements
Inside each measurement put the corresponding fields, e.g. mean_tps, max_tps, etc.