### PR TITLE
Add skip rate to fullfill #14

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -33,14 +33,16 @@ printf -v s_ct_stats_number_of_accts '%s\\n%s\\n%s\\n%s' \
         "$mean_ct_stats_num_of_accts_txt" "$max_ct_stats_num_of_accts_txt" "$p90_ct_stats_num_of_accts_txt" "$p99_ct_stats_num_of_accts_txt"
 printf -v blocks_fill '%s\\n%s\\n%s\\n%s\\n%s' \
         "$total_blocks_txt" "$blocks_fill_50_txt" "$blocks_fill_90_txt" "$blocks_fill_50_percent_txt" "$blocks_fill_90_percent_txt"
+printf -v skip_rate '%s\\n%s\\n%s\\n' \
+        "$mean_skip_rate_txt" "$mean_skip_rate_txt" "$skip_rate_90_txt"
 printf -v buildkite_link  '%s' "[Buildkite]($BUILDKITE_BUILD_URL)"
 printf -v grafana_link  '%s' "[Grafana]($gf_url)"
 # compose report without link
-printf -v test_report '%s    %s\\n%s\\n**Test Details:**\\n```%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n```' \
+printf -v test_report '%s    %s\\n%s\\n**Test Details:**\\n```%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n```' \
         "$grafana_link" "$buildkite_link" \
         "$test_config" "$time_range" "$slot_range" \
         "$s_tx_count" "$s_tower_vote_dist" "$s_optimistic_slot_elapsed" \
-        "$s_ct_stats_block_cost" "$s_ct_stats_tx_count" "$s_ct_stats_number_of_accts" "$blocks_fill" 
+        "$s_ct_stats_block_cost" "$s_ct_stats_tx_count" "$s_ct_stats_number_of_accts" "$blocks_fill" "$skip_rate"
 
 # compose discord message
 d_username="\"username\": \"${discord_bot_name}\""

--- a/discord.sh
+++ b/discord.sh
@@ -34,7 +34,7 @@ printf -v s_ct_stats_number_of_accts '%s\\n%s\\n%s\\n%s' \
 printf -v blocks_fill '%s\\n%s\\n%s\\n%s\\n%s' \
         "$total_blocks_txt" "$blocks_fill_50_txt" "$blocks_fill_90_txt" "$blocks_fill_50_percent_txt" "$blocks_fill_90_percent_txt"
 printf -v skip_rate '%s\\n%s\\n%s\\n' \
-        "$mean_skip_rate_txt" "$mean_skip_rate_txt" "$skip_rate_90_txt"
+        "$mean_skip_rate_txt" "$max_skip_rate_txt" "$skip_rate_90_txt"
 printf -v buildkite_link  '%s' "[Buildkite]($BUILDKITE_BUILD_URL)"
 printf -v grafana_link  '%s' "[Grafana]($gf_url)"
 # compose report without link

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -43,11 +43,14 @@ instances=$INSTANCES
 ## setup window interval for query
 window_interval="10s" 
 window_interval_long="10s"
+oversize_window=$(echo "${DURATION}+300" | bc)
+printf -v oversize_window "%ss" "$oversize_window"
 if [[ "$LARGE_DATA_SET" == "true" ]];then
 	[[ ! "$INFLUX_WINDOW_INTERVAL" ]] && INFLUX_WINDOW_INTERVAL="10m"
 	[[ ! "$INFLUX_WINDOW_INTERVAL_LONG" ]] && INFLUX_WINDOW_INTERVAL_LONG="30m"
 	window_interval=$INFLUX_WINDOW_INTERVAL
 	window_interval_long=$INFLUX_WINDOW_INTERVAL_LONG
+	oversize_window="12h"
 fi
 
 ## make sure 

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -322,23 +322,22 @@ blocks_fill_90_percent_txt="blocks_90_full: $percent_value"
 DATAPOINT[blocks_90_full]="$percent_raw_value"
 # skip_rate
 result_input="${FLUX_RESULT['mean_skip_rate']}"
-echo mean_skip_rate_result="$result_input"
 get_value
 [[ $_value != "na" ]] && printf -v precision "%.2f" "$_value" || precision="na"
 mean_skip_rate_txt="mean_skip_rate: $precision%"
-DATAPOINT[mean_skip_rate]="$_value"
+DATAPOINT[mean_skip_rate]="$precision"
 
 result_input="${FLUX_RESULT['max_skip_rate']}"
 get_value
 [[ $_value != "na" ]] && printf -v precision "%.2f" "$_value" || precision="na"
-mean_skip_rate_txt="max_skip_rate: $precision%"
-DATAPOINT[max_skip_rate]="$_value"
+max_skip_rate_txt="max_skip_rate: $precision%"
+DATAPOINT[max_skip_rate]="$precision"
 
 result_input="${FLUX_RESULT['skip_rate_90']}"
 get_value
 [[ $_value != "na" ]] && printf -v precision "%.2f" "$_value" || precision="na"
 skip_rate_90_txt="skip_rate_90: $precision%"
-DATAPOINT[skip_rate_90]="$_value"
+DATAPOINT[skip_rate_90]="$precision"
 
 #write data report to the influx
 

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -324,19 +324,19 @@ DATAPOINT[blocks_90_full]="$percent_raw_value"
 result_input="${FLUX_RESULT['mean_skip_rate']}"
 echo mean_skip_rate_result="$result_input"
 get_value
-printf -v precision "%.2" "$_value"
+[[ $_value != "na" ]] && printf -v precision "%.2f" "$_value" || precision="na"
 mean_skip_rate_txt="mean_skip_rate: $precision%"
 DATAPOINT[mean_skip_rate]="$_value"
 
 result_input="${FLUX_RESULT['max_skip_rate']}"
 get_value
-printf -v precision "%.2" "$_value"
+[[ $_value != "na" ]] && printf -v precision "%.2f" "$_value" || precision="na"
 mean_skip_rate_txt="max_skip_rate: $precision%"
 DATAPOINT[max_skip_rate]="$_value"
 
 result_input="${FLUX_RESULT['skip_rate_90']}"
 get_value
-printf -v precision "%.2" "$_value"
+[[ $_value != "na" ]] && printf -v precision "%.2f" "$_value" || precision="na"
 skip_rate_90_txt="skip_rate_90: $precision%"
 DATAPOINT[skip_rate_90]="$_value"
 

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -319,6 +319,7 @@ blocks_fill_90_percent_txt="blocks_90_full: $percent_value"
 DATAPOINT[blocks_90_full]="$percent_raw_value"
 # skip_rate
 result_input="${FLUX_RESULT['mean_skip_rate']}"
+echo mean_skip_rate_result="$result_input"
 get_value
 mean_skip_rate_txt="mean_skip_rate: $_value%"
 DATAPOINT[mean_skip_rate]="$_value"

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -324,17 +324,20 @@ DATAPOINT[blocks_90_full]="$percent_raw_value"
 result_input="${FLUX_RESULT['mean_skip_rate']}"
 echo mean_skip_rate_result="$result_input"
 get_value
-mean_skip_rate_txt="mean_skip_rate: $_value%"
+printf -v precision "%.2" "$_value"
+mean_skip_rate_txt="mean_skip_rate: $precision%"
 DATAPOINT[mean_skip_rate]="$_value"
 
 result_input="${FLUX_RESULT['max_skip_rate']}"
 get_value
-mean_skip_rate_txt="max_skip_rate: $_value%"
+printf -v precision "%.2" "$_value"
+mean_skip_rate_txt="max_skip_rate: $precision%"
 DATAPOINT[max_skip_rate]="$_value"
 
 result_input="${FLUX_RESULT['skip_rate_90']}"
 get_value
-skip_rate_90_txt="skip_rate_90: $_value%"
+printf -v precision "%.2" "$_value"
+skip_rate_90_txt="skip_rate_90: $precision%"
 DATAPOINT[skip_rate_90]="$_value"
 
 #write data report to the influx

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -317,6 +317,21 @@ else
 fi
 blocks_fill_90_percent_txt="blocks_90_full: $percent_value"
 DATAPOINT[blocks_90_full]="$percent_raw_value"
+# skip_rate
+result_input="${FLUX_RESULT['mean_skip_rate']}"
+get_value
+mean_skip_rate_txt="mean_skip_rate: $_value%"
+DATAPOINT[mean_skip_rate]="$_value"
+
+result_input="${FLUX_RESULT['max_skip_rate']}"
+get_value
+mean_skip_rate_txt="max_skip_rate: $_value%"
+DATAPOINT[max_skip_rate]="$_value"
+
+result_input="${FLUX_RESULT['skip_rate_90']}"
+get_value
+skip_rate_90_txt="skip_rate_90: $_value%"
+DATAPOINT[skip_rate_90]="$_value"
 
 #write data report to the influx
 

--- a/influx_data.sh
+++ b/influx_data.sh
@@ -234,7 +234,8 @@ _mean_skip_rate='data_max=from(bucket: "tds")|> range(start:'${start_time}' ,sto
 				|> map(fn: (r) => ({ r with skip_slot: r.slot_diff - r.block_diff }))
 				|> filter(fn: (r) => r.slot_diff > 0)
 				|> map(fn: (r) => ({ r with skip_rate_percent: r.skip_slot*100/r.slot_diff }))
-				|> keep(columns: ["skip_rate_percent"])|> group()|> mean(column:"skip_rate_percent")'
+				|> keep(columns: ["skip_rate_percent"])|> group()|> mean(column:"skip_rate_percent")
+				|> rename(columns: {skip_rate_percent: "_value"})'
 _max_skip_rate='data_max=from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
 				|> filter(fn: (r) => r["_measurement"] == "bank-new_from_parent-heights")
 				|> filter(fn: (r) => r["_field"] == "slot" or r["_field"] == "block_height")
@@ -259,7 +260,8 @@ _max_skip_rate='data_max=from(bucket: "tds")|> range(start:'${start_time}' ,stop
 				|> map(fn: (r) => ({ r with skip_slot: r.slot_diff - r.block_diff }))
 				|> filter(fn: (r) => r.slot_diff > 0)
 				|> map(fn: (r) => ({ r with skip_rate_percent: r.skip_slot*100/r.slot_diff }))
-				|> keep(columns: ["skip_rate_percent"])|> group()|> max(column:"skip_rate_percent")'
+				|> keep(columns: ["skip_rate_percent"])|> group()|> max(column:"skip_rate_percent")
+				|> rename(columns: {skip_rate_percent: "_value"})'
 
 _skip_rate_90='data_max=from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
 				|> filter(fn: (r) => r["_measurement"] == "bank-new_from_parent-heights")
@@ -285,7 +287,8 @@ _skip_rate_90='data_max=from(bucket: "tds")|> range(start:'${start_time}' ,stop:
 				|> map(fn: (r) => ({ r with skip_slot: r.slot_diff - r.block_diff }))
 				|> filter(fn: (r) => r.slot_diff > 0)
 				|> map(fn: (r) => ({ r with skip_rate_percent: r.skip_slot*100/r.slot_diff }))
-				|> keep(columns: ["skip_rate_percent"])|> group()|> quantile(column: "skip_rate_percent", q: 0.90)'
+				|> keep(columns: ["skip_rate_percent"])|> group()|> quantile(column: "skip_rate_percent", q: 0.90)
+				|> rename(columns: {skip_rate_percent: "_value"})'
 
 declare -A FLUX  # FLUX command
 FLUX[start_slot]=$_start_slot

--- a/influx_data.sh
+++ b/influx_data.sh
@@ -209,6 +209,83 @@ _blocks_fill_90='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop
   				|> aggregateWindow(every: '${window_interval}',  fn: (column, tables=<-) => tables |>  count(column: "bank_slot"))
     			|> sum(column: "bank_slot")
 				|> drop(columns: ["_start", "_stop"])'
+#skip_rate
+_mean_skip_rate='data_max=from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
+				|> filter(fn: (r) => r["_measurement"] == "bank-new_from_parent-heights")
+				|> filter(fn: (r) => r["_field"] == "slot" or r["_field"] == "block_height")
+				|> aggregateWindow(every:'${oversize_window}', fn:max)
+				|> max()
+				|> group(columns: ["host_id"], mode:"by")
+				data_min=from(bucket: "tds")
+				|> range(start:'${start_time}' ,stop:'${stop_time}')
+				|> filter(fn: (r) => r["_measurement"] == "bank-new_from_parent-heights")
+				|> filter(fn: (r) => r["_field"] == "slot" or r["_field"] == "block_height")
+				|> aggregateWindow(every: '${oversize_window}', fn:min)
+				|> max()
+				|> group(columns: ["host_id"], mode:"by")
+				block_max=data_max|> filter(fn: (r) => r["_field"] == "block_height")|> set(key: "_field", value: "block_max")
+				block_min=data_min|> filter(fn: (r) => r["_field"] == "block_height")|> set(key: "_field", value: "block_min")
+				slot_max=data_max|> filter(fn: (r) => r["_field"] == "slot")|> set(key: "_field", value: "slot_max")
+				slot_min=data_min|> filter(fn: (r) => r["_field"] == "slot")|> set(key: "_field", value: "slot_min")
+				union(tables: [block_max, block_min, slot_max, slot_min])
+				|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+				|> map(fn: (r) => ({ r with block_diff: r.block_max - r.block_min }))
+				|> map(fn: (r) => ({ r with slot_diff: r.slot_max - r.slot_min }))
+				|> map(fn: (r) => ({ r with skip_slot: r.slot_diff - r.block_diff }))
+				|> filter(fn: (r) => r.slot_diff > 0)
+				|> map(fn: (r) => ({ r with skip_rate_percent: r.skip_slot*100/r.slot_diff }))
+				|> keep(columns: ["skip_rate_percent"])|> group()|> mean(column:"skip_rate_percent")'
+_max_skip_rate='data_max=from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
+				|> filter(fn: (r) => r["_measurement"] == "bank-new_from_parent-heights")
+				|> filter(fn: (r) => r["_field"] == "slot" or r["_field"] == "block_height")
+				|> aggregateWindow(every:'${oversize_window}', fn:max)
+				|> max()
+				|> group(columns: ["host_id"], mode:"by")
+				data_min=from(bucket: "tds")
+				|> range(start:'${start_time}' ,stop:'${stop_time}')
+				|> filter(fn: (r) => r["_measurement"] == "bank-new_from_parent-heights")
+				|> filter(fn: (r) => r["_field"] == "slot" or r["_field"] == "block_height")
+				|> aggregateWindow(every: '${oversize_window}', fn:min)
+				|> max()
+				|> group(columns: ["host_id"], mode:"by")
+				block_max=data_max|> filter(fn: (r) => r["_field"] == "block_height")|> set(key: "_field", value: "block_max")
+				block_min=data_min|> filter(fn: (r) => r["_field"] == "block_height")|> set(key: "_field", value: "block_min")
+				slot_max=data_max|> filter(fn: (r) => r["_field"] == "slot")|> set(key: "_field", value: "slot_max")
+				slot_min=data_min|> filter(fn: (r) => r["_field"] == "slot")|> set(key: "_field", value: "slot_min")
+				union(tables: [block_max, block_min, slot_max, slot_min])
+				|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+				|> map(fn: (r) => ({ r with block_diff: r.block_max - r.block_min }))
+				|> map(fn: (r) => ({ r with slot_diff: r.slot_max - r.slot_min }))
+				|> map(fn: (r) => ({ r with skip_slot: r.slot_diff - r.block_diff }))
+				|> filter(fn: (r) => r.slot_diff > 0)
+				|> map(fn: (r) => ({ r with skip_rate_percent: r.skip_slot*100/r.slot_diff }))
+				|> keep(columns: ["skip_rate_percent"])|> group()|> max(column:"skip_rate_percent")'
+
+_skip_rate_90='data_max=from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
+				|> filter(fn: (r) => r["_measurement"] == "bank-new_from_parent-heights")
+				|> filter(fn: (r) => r["_field"] == "slot" or r["_field"] == "block_height")
+				|> aggregateWindow(every:'${oversize_window}', fn:max)
+				|> max()
+				|> group(columns: ["host_id"], mode:"by")
+				data_min=from(bucket: "tds")
+				|> range(start:'${start_time}' ,stop:'${stop_time}')
+				|> filter(fn: (r) => r["_measurement"] == "bank-new_from_parent-heights")
+				|> filter(fn: (r) => r["_field"] == "slot" or r["_field"] == "block_height")
+				|> aggregateWindow(every: '${oversize_window}', fn:min)
+				|> max()
+				|> group(columns: ["host_id"], mode:"by")
+				block_max=data_max|> filter(fn: (r) => r["_field"] == "block_height")|> set(key: "_field", value: "block_max")
+				block_min=data_min|> filter(fn: (r) => r["_field"] == "block_height")|> set(key: "_field", value: "block_min")
+				slot_max=data_max|> filter(fn: (r) => r["_field"] == "slot")|> set(key: "_field", value: "slot_max")
+				slot_min=data_min|> filter(fn: (r) => r["_field"] == "slot")|> set(key: "_field", value: "slot_min")
+				union(tables: [block_max, block_min, slot_max, slot_min])
+				|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+				|> map(fn: (r) => ({ r with block_diff: r.block_max - r.block_min }))
+				|> map(fn: (r) => ({ r with slot_diff: r.slot_max - r.slot_min }))
+				|> map(fn: (r) => ({ r with skip_slot: r.slot_diff - r.block_diff }))
+				|> filter(fn: (r) => r.slot_diff > 0)
+				|> map(fn: (r) => ({ r with skip_rate_percent: r.skip_slot*100/r.slot_diff }))
+				|> keep(columns: ["skip_rate_percent"])|> group()|> quantile(column: "skip_rate_percent", q: 0.90)'
 
 declare -A FLUX  # FLUX command
 FLUX[start_slot]=$_start_slot
@@ -255,7 +332,10 @@ FLUX[p99_ct_stats_number_of_accounts]=$_99_ct_stats_number_of_accounts
 FLUX[total_blocks]=$_total_blocks
 FLUX[blocks_fill_50]=$_blocks_fill_50
 FLUX[blocks_fill_90]=$_blocks_fill_90
-
+# skip rate
+FLUX[mean_skip_rate]=$_mean_skip_rate
+FLUX[max_skip_rate]=$_max_skip_rate
+FLUX[skip_rate_90]=$_skip_rate_90
 # Dos Report write to Influxdb
 
 declare -A FIELD_MEASUREMENT
@@ -301,3 +381,8 @@ FIELD_MEASUREMENT[numb_blocks_50_full]=block_fill
 FIELD_MEASUREMENT[numb_blocks_90_full]=block_fill
 FIELD_MEASUREMENT[blocks_50_full]=block_fill
 FIELD_MEASUREMENT[blocks_90_full]=block_fill
+
+# skip rate
+FIELD_MEASUREMENT[mean_skip_rate]=skip_rate
+FIELD_MEASUREMENT[max_skip_rate]=skip_rate
+FIELD_MEASUREMENT[skip_rate_90]=skip_rate

--- a/slack.sh
+++ b/slack.sh
@@ -26,8 +26,9 @@ printf -v s_ct_stats_block_cost "%s%s%s%s%s%s%s%s" $mean_ct_stats_block_cost_txt
 printf -v s_ct_stats_tx_count "%s%s%s%s%s%s%s%s" $mean_mean_ct_stats_tx_count_txt "\\n" $max_mean_ct_stats_tx_count_txt "\\n" $p90_mean_ct_stats_tx_count_txt "\\n" $p99_mean_ct_stats_tx_count_txt "\\n"
 printf -v s_ct_stats_number_of_accts "%s%s%s%s%s%s%s%s" $mean_ct_stats_num_of_accts_txt "\\n" $max_ct_stats_num_of_accts_txt "\\n" $p90_ct_stats_num_of_accts_txt "\\n" $p99_ct_stats_num_of_accts_txt "\\n"
 printf -v blocks_fill "%s%s%s%s%s%s%s%s%s%s" $total_blocks_txt "\\n" $blocks_fill_50_txt "\\n" $blocks_fill_90_txt "\\n" $blocks_fill_50_percent_txt "\\n"  $blocks_fill_90_percent_txt "\\n"
+printf -v skip_rate "%s%s%s%s%s%s" $mean_skip_rate_txt "\\n" $max_skip_rate_txt "\\n" $skip_rate_90_txt "\\n"
 # combine all data
-printf -v s_detail_ret "%s%s%s%s%s%s%s%s%s%s" $s_time_start $s_time_end $s_slot $s_tx_count $s_tower_vote_distance $s_optimistic_slot_elapsed $s_ct_stats_block_cost $s_ct_stats_tx_count $s_ct_stats_number_of_accts $blocks_fill
+printf -v s_detail_ret "%s%s%s%s%s%s%s%s%s%s%s" $s_time_start $s_time_end $s_slot $s_tx_count $s_tower_vote_distance $s_optimistic_slot_elapsed $s_ct_stats_block_cost $s_ct_stats_tx_count $s_ct_stats_number_of_accts $blocks_fill $skip_rate
 ## Compose block content
 conf='"```'${test_config}'```"'
 detail='"```'${s_detail_ret}'```"'


### PR DESCRIPTION
[problem]
There are requests about adding skip-rate of slots to the dos report
[solution]
add mean_skip_rate/max_skip_rate/skip_rate_90 to the report by using pipeline query of FLUX language.
[method]
- finding max and min of slots and blocks for each host_id
- find skip_slot by calculating block_diff & slot diff for each host_id
- get skip_rate_percent by "r.skip_slot*100/r.slot_diff " for each host_id
- get the mean/max/90% of skip_rate by calculating among hosts.
- write mean_skip_rate/max_skip_rate/skip_rate_90 to the report and influxdb