### PR TITLE
update mean_tps query method to fullfill issue #17

### DIFF
--- a/dos-report.sh
+++ b/dos-report.sh
@@ -4,6 +4,7 @@ set -ex
 # read env
 source dos-report-env.sh
 source env-artifact.sh
+source utils.sh
 # check ENV
 # no env , exit
 [[ ! $DISCORD_AVATAR_URL ]]&&DISCORD_AVATAR_URL="https://i.imgur.com/LJismmJ.jpg" || echo use DISCORD_AVATAR_URL=$DISCORD_AVATAR_URL
@@ -178,23 +179,31 @@ result_input=${FLUX_RESULT['end_slot']}
 get_value
 end_slot_txt="end_slot: $_value"
 DATAPOINT[end_slot]="$_value"
-#  TPS
+# TPS : the query result is tps*{$window_interval}, so we need to divide {$window_interval} to get the real tps
 result_input=${FLUX_RESULT['mean_tx_count']}
 get_value
-mean_tx_count_txt="mean_tps: $_value"
-DATAPOINT[mean_tps]="$_value"
+extract_time_in_sec "${window_interval}"
+[[ ${duration_in_seconds} -eq "0" ]]&&  tps="0" || tps=$(echo "scale=0;$_value/${duration_in_seconds}"|bc)
+mean_tx_count_txt="mean_tps: $tps"
+DATAPOINT[mean_tps]="$tps"
 result_input=${FLUX_RESULT['max_tx_count']}
 get_value
-max_tx_count_txt="max_tps: $_value"
-DATAPOINT[max_tps]="$_value"
+extract_time_in_sec "${window_interval}"
+[[ ${duration_in_seconds} -eq "0" ]]&&  tps="0" || tps=$(echo "scale=0;$_value/${duration_in_seconds}"|bc)
+max_tx_count_txt="max_tps: $tps"
+DATAPOINT[max_tps]="$tps"
 result_input=${FLUX_RESULT['p90_tx_count']}
 get_value
-p90_tx_count_txt="90th_tx_count: $_value"
-DATAPOINT[90th_tx_count]="$_value"
+extract_time_in_sec "${window_interval}"
+[[ ${duration_in_seconds} -eq "0" ]]&&  tps="0" || tps=$(echo "scale=0;$_value/${duration_in_seconds}"|bc)
+p90_tx_count_txt="90th_tx_count: $tps"
+DATAPOINT[90th_tx_count]="$tps"
 result_input="${FLUX_RESULT['p99_tx_count']}"
 get_value
-p99_tx_count_txt="99th_tx_count: $_value"
-DATAPOINT[99th_tx_count]="$_value"
+extract_time_in_sec "${window_interval}"
+tps=$(echo "scale=0;$_value/${duration_in_seconds}"|bc)
+p99_tx_count_txt="99th_tx_count: $tps"
+DATAPOINT[99th_tx_count]="$tps"
 # tower distance
 result_input="${FLUX_RESULT['mean_tower_vote_distance']}"
 echo "${FLUX_RESULT['mean_tower_vote_distance']}"

--- a/influx_data.sh
+++ b/influx_data.sh
@@ -10,37 +10,29 @@ _end_slot='from(bucket: "tds")|> range(start:'${stop_time2}' ,stop:'${stop_time}
 			|> group(columns: ["slot"])|> median()
 			|> drop(columns: ["_measurement", "_field", "_start", "_stop","_time","host_id", "slot"])'
 
-# TPS
+# TPS: Notetice that tthe result of TPS need to divide window_interval to get the correct result
 _mean_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count")
-	   				|> aggregateWindow(every: '${window_interval}', fn: mean)
-					|> group()|>mean()|>toInt()
-					|> drop(columns: ["_start", "_stop","count"])'
+    				|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
+    				|> aggregateWindow(every:'${window_interval}', fn: sum)
+    				|> group() |> median()|>toInt()'
 _max_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count")
-	   				|> aggregateWindow(every: '${window_interval}', fn: max)
-					|> group()|>max()|>toInt()
-					|> drop(columns: ["_measurement", "_field", "_start", "_stop","_time","host_id","count"])'
+    				|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
+    				|> aggregateWindow(every:'${window_interval}', fn: sum)
+    				|> group() |> max()
+					|>drop(columns: ["_measurement", "_start", "_stop","host_id","_field"])'
 _min_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count")
-	   				|> aggregateWindow(every: '${window_interval}', fn: min)
-					|> group()|>min()|>toInt()
-					|> drop(columns: ["_measurement", "_field", "_start", "_stop","_time","host_id","count"])'
-
+    				|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
+    				|> aggregateWindow(every:'${window_interval}', fn: sum)
+    				|> group() |> min()'
 _90_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count" )
-    				|> aggregateWindow(every: '${window_interval_long}',  fn: (column, tables=<-) => tables |> quantile(q: 0.9))
-    				|> group()
-    				|> quantile(column: "_value", q:0.9)|>toInt()
-    				|> drop(columns: ["_measurement", "_field", "_start", "_stop","count"])'
+					|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
+    				|> aggregateWindow(every: '${window_interval_long}',  fn: sum)
+    				|> group()|> quantile(column: "_value", q:0.9)'
 
 _99_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count" )
-    				|> aggregateWindow(every: '${window_interval_long}',  fn: (column, tables=<-) => tables |> quantile(q: 0.99))
-    				|> group()
-    				|> quantile(column: "_value", q:0.99)|>toInt()
-    				|> drop(columns: ["_measurement", "_field", "_start", "_stop","count"])'
-
+					|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
+    				|> aggregateWindow(every: '${window_interval_long}',  fn: sum)
+    				|> group()|> quantile(column: "_value", q:0.99)'
 # tower distance
 _mean_tower_vote_distance='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
 					|> filter(fn: (r) => r._measurement == "tower-vote")

--- a/utils.sh
+++ b/utils.sh
@@ -61,3 +61,30 @@ get_time_before() {
 	outcom_in_sec=$(echo $1 - $2 | bc) 
     echo $outcom_in_sec
 }
+
+# extract_time: extract number and unit from string like 10s, 10m, 10h
+# argv1: string like 10s, 10m, 10h
+# return: use $duration_in_seconds or return value $?
+function extract_time_in_sec {
+    if [[ $1 =~ ^([0-9]+)([smh])$ ]]; then
+        number="${BASH_REMATCH[1]}"
+        unit="${BASH_REMATCH[2]}"
+
+        case "$unit" in
+            s)
+                duration_in_seconds="$number"
+                ;;
+            m)
+                duration_in_seconds=$((number * 60))
+                ;;
+            h)
+                duration_in_seconds=$((number * 3600))
+                ;;
+            *)
+            duration_in_seconds=0
+                ;;
+        esac
+        echo "$duration_in_seconds"
+    fi
+}
+


### PR DESCRIPTION
[problem]
The "bank-process_transactions" datapoint, which was used by dos-report to calculate mean_tps, has been removed in v1.16.
https://github.com/solana-labs/solana/pull/31398
[solution]
modify influx query similar to below
https://github.com/solana-labs/solana/pull/31531